### PR TITLE
Identity service usage by metaservice and nfs provider

### DIFF
--- a/controllers/app/app.go
+++ b/controllers/app/app.go
@@ -19,6 +19,7 @@ package app
 import (
 	"context"
 	"fmt"
+
 	"github.com/pkg/errors"
 
 	"os"

--- a/controllers/app/config/config.go
+++ b/controllers/app/config/config.go
@@ -18,13 +18,14 @@ package config
 
 import (
 	log "github.com/sirupsen/logrus"
-	"github.com/soda-cdm/kahu/client/clientset/versioned"
-	"github.com/soda-cdm/kahu/client/informers/externalversions"
 	apiv1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/scheme"
 	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/client-go/tools/record"
+
+	"github.com/soda-cdm/kahu/client/clientset/versioned"
+	"github.com/soda-cdm/kahu/client/informers/externalversions"
 
 	"github.com/soda-cdm/kahu/client"
 	"github.com/soda-cdm/kahu/controllers/backup"

--- a/controllers/app/options/manager.go
+++ b/controllers/app/options/manager.go
@@ -18,6 +18,7 @@ package options
 
 import (
 	"fmt"
+
 	"github.com/soda-cdm/kahu/controllers/app/config"
 
 	"github.com/spf13/pflag"

--- a/controllers/manager/controllermanager.go
+++ b/controllers/manager/controllermanager.go
@@ -19,6 +19,7 @@ package manager
 import (
 	"context"
 	"fmt"
+
 	"github.com/soda-cdm/kahu/controllers"
 
 	log "github.com/sirupsen/logrus"

--- a/providerframework/metaservice/app/app.go
+++ b/providerframework/metaservice/app/app.go
@@ -27,6 +27,7 @@ import (
 	"github.com/spf13/pflag"
 	"google.golang.org/grpc"
 
+	providerIdentity "github.com/soda-cdm/kahu/providerframework/identityservice"
 	"github.com/soda-cdm/kahu/providerframework/metaservice/app/options"
 	repo "github.com/soda-cdm/kahu/providerframework/metaservice/backuprespository"
 	metaservice "github.com/soda-cdm/kahu/providerframework/metaservice/lib/go"
@@ -133,8 +134,15 @@ func Run(ctx context.Context, serviceOptions options.MetaServiceOptions) error {
 	}
 
 	// initialize backup repository
-	repository, err := repo.NewBackupRepository(serviceOptions.BackupDriverAddress)
+	repository, grpcConn, err := repo.NewBackupRepository(serviceOptions.BackupDriverAddress)
 	if err != nil {
+		return err
+	}
+
+	// Register the metadata provider
+	err = providerIdentity.RegisterMetadataProvider(ctx, &grpcConn)
+	if err != nil {
+		log.Error("Failed to get provider info: ", err)
 		return err
 	}
 

--- a/providerframework/metaservice/archiver/compressors/gzip.go
+++ b/providerframework/metaservice/archiver/compressors/gzip.go
@@ -18,6 +18,7 @@ package compressors
 
 import (
 	"compress/gzip"
+
 	"github.com/soda-cdm/kahu/providerframework/metaservice/archiver"
 	"github.com/soda-cdm/kahu/providerframework/metaservice/archiver/manager"
 )

--- a/providerframework/metaservice/archiver/tar/tar.go
+++ b/providerframework/metaservice/archiver/tar/tar.go
@@ -18,8 +18,9 @@ package tar
 
 import (
 	"archive/tar"
-	log "github.com/sirupsen/logrus"
 	"time"
+
+	log "github.com/sirupsen/logrus"
 
 	"github.com/soda-cdm/kahu/providerframework/metaservice/archiver"
 )

--- a/providers/nfs_provider/server/app.go
+++ b/providers/nfs_provider/server/app.go
@@ -134,6 +134,6 @@ func Run(ctx context.Context, serviceOptions options.NFSProviderOptions) error {
 	var opts []grpc.ServerOption
 	grpcServer := grpc.NewServer(opts...)
 	nfs_provider.RegisterMetaBackupServer(grpcServer, NewMetaBackupServer(ctx, serviceOptions))
-
+	nfs_provider.RegisterIdentityServer(grpcServer, NewIdentityServer(ctx, serviceOptions))
 	return grpcServer.Serve(lis)
 }

--- a/providers/nfs_provider/server/options/flags.go
+++ b/providers/nfs_provider/server/options/flags.go
@@ -23,6 +23,12 @@ import (
 	"github.com/spf13/pflag"
 )
 
+const (
+	// NFSService component name
+	unixSocketPath = "/tmp/nfs.sock"
+	DataPath       = "/data"
+)
+
 type CompressionType string
 
 type NFSServiceFlags struct {
@@ -32,8 +38,8 @@ type NFSServiceFlags struct {
 
 func NewNFSServiceFlags() *NFSServiceFlags {
 	return &NFSServiceFlags{
-		UnixSocketPath: "/tmp/nfs.sock",
-		DataPath:       "/data",
+		UnixSocketPath: unixSocketPath,
+		DataPath:       DataPath,
 	}
 }
 

--- a/providers/nfs_provider/server/server.go
+++ b/providers/nfs_provider/server/server.go
@@ -30,7 +30,9 @@ import (
 )
 
 const (
-	READ_BUFFER_SIZE int = 4096
+	defaultProviderName        = "kahu-nfs-provider"
+	defaultProviderVersion     = "v1"
+	READ_BUFFER_SIZE       int = 4096
 )
 
 type nfsServer struct {
@@ -46,6 +48,46 @@ func NewMetaBackupServer(ctx context.Context,
 	}
 }
 
+func NewIdentityServer(ctx context.Context,
+	serviceOptions options.NFSProviderOptions) pb.IdentityServer {
+	return &nfsServer{
+		ctx:     ctx,
+		options: serviceOptions,
+	}
+}
+
+// GetProviderInfo returns the basic information from provider side
+func (server *nfsServer) GetProviderInfo(ctx context.Context, GetProviderInfoRequest *pb.GetProviderInfoRequest) (*pb.GetProviderInfoResponse, error) {
+	log.Info("GetProviderInfo Called .... ")
+	response := &pb.GetProviderInfoResponse{
+		Provider: defaultProviderName,
+		Version:  defaultProviderVersion}
+
+	return response, nil
+}
+
+// GetProviderCapabilities returns the capabilities supported by provider
+func (server *nfsServer) GetProviderCapabilities(ctx context.Context, GetProviderCapabilitiesRequest *pb.GetProviderCapabilitiesRequest) (*pb.GetProviderCapabilitiesResponse, error) {
+	log.Info("GetProviderCapabilities Called .... ")
+	return &pb.GetProviderCapabilitiesResponse{
+		Capabilities: []*pb.ProviderCapability{
+			{
+				Type: &pb.ProviderCapability_Service_{
+					Service: &pb.ProviderCapability_Service{
+						Type: pb.ProviderCapability_Service_META_BACKUP_SERVICE,
+					},
+				},
+			},
+		},
+	}, nil
+}
+
+// Probe checks the healthy/availability state of the provider
+func (server *nfsServer) Probe(ctx context.Context, probeRequest *pb.ProbeRequest) (*pb.ProbeResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method Probe not implemented")
+}
+
+// Upload pushes the input data to the specified location at provider
 func (server *nfsServer) Upload(service pb.MetaBackup_UploadServer) error {
 	log.Info("Upload Called .... ")
 
@@ -101,6 +143,7 @@ func (server *nfsServer) Upload(service pb.MetaBackup_UploadServer) error {
 	return nil
 }
 
+// Download pulls the input file from the specified location at provider
 func (server *nfsServer) Download(request *pb.DownloadRequest,
 	service pb.MetaBackup_DownloadServer) error {
 	log.Info("Download Called ...")
@@ -160,6 +203,7 @@ func (server *nfsServer) Download(request *pb.DownloadRequest,
 	return nil
 }
 
+// Delete removes the input file from the specified location at provider
 func (server *nfsServer) Delete(ctxt context.Context,
 	request *pb.DeleteRequest) (*pb.Empty, error) {
 	log.Info("Delete Called ...")
@@ -186,6 +230,7 @@ func (server *nfsServer) Delete(ctxt context.Context,
 	return &empty, nil
 }
 
+// ObjectExists checks if input file exists at provider
 func (server *nfsServer) ObjectExists(ctxt context.Context,
 	request *pb.ObjectExistsRequest) (*pb.ObjectExistsResponse, error) {
 	log.Info("ObjectExists Called...")

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -19,10 +19,11 @@ package utils
 import (
 	"context"
 	"fmt"
-	log "github.com/sirupsen/logrus"
 	"os"
 	"os/signal"
 	"syscall"
+
+	log "github.com/sirupsen/logrus"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	restclient "k8s.io/client-go/rest"


### PR DESCRIPTION
**What type of PR is this?**
/kind new feature

**What this PR does / why we need it**:
Identity service of provider framework exposes APIs for providers to exchange their basic information and capability information
and based on this info, it create Provider CRD

This PR contains 
1) identity service API trigger by metaservice
2) identity service api implementation from nfs side

**Which issue(s) this PR fixes**:
<!--
*Please provide the issues number or link.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Test Report Added?**:
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
> /kind TESTED

**Test Report**:
![image](https://user-images.githubusercontent.com/30930862/176999636-5ca5d1c4-0131-47ec-9d2b-8eff02b5211c.png)


**Special notes for your reviewer**:
