### PR TITLE
Update backup handle usage mechanism

### DIFF
--- a/providerframework/volumeservice/backup/backupvolume.go
+++ b/providerframework/volumeservice/backup/backupvolume.go
@@ -476,7 +476,7 @@ func (ctrl *controller) getSnapshotBySnapshotState(
 	}
 
 	return &providerSvc.Snapshot{
-		SnapshotHandle: *csiVolSnapshotContent.Status.SnapshotHandle,
+		SnapshotHandle: csiVolSnapshotContent.Name,
 	}, nil
 }
 

--- a/providers/csi-snapshotter/server/server.go
+++ b/providers/csi-snapshotter/server/server.go
@@ -26,7 +26,6 @@ import (
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
-	"strings"
 
 	"github.com/soda-cdm/kahu/client"
 	"github.com/soda-cdm/kahu/providers/csi-snapshotter/server/options"
@@ -169,11 +168,7 @@ func (server *volBackupServer) CreateVolumeFromBackup(ctx context.Context,
 	restoreIDs := make([]*pb.RestoreVolumeIdentifier, 0)
 	for _, restoreInfo := range restoreReq.RestoreInfo {
 		log.Infof("CreateVolumeFromBackup ....%+v", restoreInfo)
-		backupHandle := restoreInfo.GetBackupIdentity().BackupHandle
-		log.Infof("CreateVolumeFromBackup backupHandle....%+v", backupHandle)
-		//bacjupHandleSplit := strings.Split(backupHandle, "@")
-		//snapshotHandle := bacjupHandleSplit[1]
-		snapshotContentName := strings.ReplaceAll(backupHandle, "snapshot", "snapcontent")
+		snapshotContentName := restoreInfo.GetBackupIdentity().BackupHandle
 		log.Infof("CreateVolumeFromBackup snapshotContentName....%+v", snapshotContentName)
 		snapshotContent, err := server.snapshotCli.SnapshotV1().
 			VolumeSnapshotContents().

--- a/providers/openebs-zfs/server/server.go
+++ b/providers/openebs-zfs/server/server.go
@@ -19,7 +19,6 @@ package server
 
 import (
 	"context"
-	"strings"
 
 	snapshotapi "github.com/kubernetes-csi/external-snapshotter/client/v4/apis/volumesnapshot/v1"
 	snapshotclientset "github.com/kubernetes-csi/external-snapshotter/client/v4/clientset/versioned"
@@ -168,11 +167,7 @@ func (server *volBackupServer) CreateVolumeFromBackup(ctx context.Context,
 
 	restoreIDs := make([]*pb.RestoreVolumeIdentifier, 0)
 	for _, restoreInfo := range restoreReq.RestoreInfo {
-		backupHandle := restoreInfo.GetBackupIdentity().BackupHandle
-		bacjupHandleSplit := strings.Split(backupHandle, "@")
-		snapshotHandle := bacjupHandleSplit[1]
-		snapshotContentName := strings.ReplaceAll(snapshotHandle, "snapshot", "snapcontent")
-
+		snapshotContentName := restoreInfo.GetBackupIdentity().BackupHandle
 		snapshotContent, err := server.snapshotCli.SnapshotV1().
 			VolumeSnapshotContents().
 			Get(context.TODO(), snapshotContentName, metav1.GetOptions{})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Please give clear description and fill all the needed fields in the PR template below
2. Provide all the test report and results for the PR. It is mandatory. Otherwise, 
   your PR may get rejected without any review/discussion
3. If the PR is incomplete/in progress, please add [WIP] at the beginning of the PR title.
4. Provide the link to the issue and other relevant files related to the PR
-->

**What type of PR is this?**
kind enhancement

**What this PR does / why we need it**:
In current mechanism, kahu volume service uses snapshot handle in volume content status as the handle to keep the mapping between snapshots and corresponding backups. But this snapshot handle creating mechanism can different across different drivers.
So tracing back during restore can not be a common mechanism across different csi drivers

So in new mechanism, kahu volume service will use snapshot content name itself as the handle to map between backups and snapshots

**Which issue(s) this PR fixes**:

Fixes #https://github.com/soda-cdm/kahu/issues/185

**Test Report Added?**:
kind TESTED

**Test Report**:
Verify that snapshot name is used as handle in volumebackupcontent (VBC)
![backuphandle-change](https://github.com/soda-cdm/kahu/assets/30930862/bf907a06-5c75-4a26-9529-5fe2e9806a17)


**Special notes for your reviewer**:
